### PR TITLE
Small fixes

### DIFF
--- a/fiplr.el
+++ b/fiplr.el
@@ -69,7 +69,8 @@
   "An alist of files and directories to exclude from searches.")
 
 (defgroup fiplr nil
-  "Configuration options for fiplr - find in project.")
+  "Configuration options for fiplr - find in project."
+  :group 'convenience)
 
 (defcustom fiplr-root-markers *fiplr-default-root-markers*
   "A list of files or directories that are found at the root of a project."


### PR DESCRIPTION
Hi,

While working on #34 I came across these two minor points. 

Aside from changing `use` to `easy`, which is what I think is meant, I also re-filled the paragraph, since `easy` is a **whopping** one character longer.

Please feel free to merge or cherry-pick neither, either or both these commits.
