### PR TITLE
Ensure clearing the cache always yields a new list

### DIFF
--- a/fiplr.el
+++ b/fiplr.el
@@ -154,7 +154,9 @@ directory is opened using `dired-other-frame'."
 (defun fiplr-clear-cache ()
   "Clears the internal caches used by fiplr so the project is searched again."
   (interactive)
-  (setq *fiplr-caches* '((files) (directories))))
+  (setq *fiplr-caches*
+        (list (list 'files)
+              (list 'directories))))
 
 ;;; --- Minor Mode Definition
 


### PR DESCRIPTION
Hi,

By using the `list` function we ensure we don't reuse the same value
like when using a quoted list literal.

While I was working on my previous patches I noticed that the
`fiplr-clear-cache` function only cleared the cache the first time I
called it. This seems to have something to do with the fact that a
quoted list is used to clear it. Instead of setting the
`*fiplr-caches*` to a fresh new list it keeps setting it to the same
list, which has since been populated with data.
1. Use `fiplr-find-file` to populate the cache.
2. Inspect `*fiplr-caches*`, it should be filled with data.
3. Call `fiplr-clear-cache` and check that `*fiplr-caches*` is now
   empty.
4. Repeat steps 1-3, but notice that this time the `*fiplr-caches*`
   variable is _not_ empty.

I tried this on both the Emacs trunk version and Emacs 24.3.

Please let me know what you think.
